### PR TITLE
Fix travis CI error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
         apt:
           sources:
             - llvm-toolchain-trusty-6.0
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
           packages:
             - llvm-6.0
             - llvm-6.0-dev


### PR DESCRIPTION
This is related #6   
I guess Travis CI using Ubuntu 14.04. It is too old.
So It Need ppa:ubuntu-toolchain-r/test.
