### PR TITLE
Fix compile ia error

### DIFF
--- a/ia/src/lib.rs
+++ b/ia/src/lib.rs
@@ -69,6 +69,7 @@
 //! full code & project layout.
 
 #![feature(fnbox)]
+#![feature(never_type)]
 
 pub extern crate futures;
 pub extern crate cwa;


### PR DESCRIPTION
In the rustc and cargo 1.27.0-nightly, I saw compile error when compiling ia as below.
```
error[E0658]: The `!` type is experimental (see issue #35121)
 --> src/executor.rs:7:51
  |
7 |     fut: UnsafeCell<Box<Future<Item = (), Error = !> + 'static>>
  |                                                   ^
  |
  = help: add #![feature(never_type)] to the crate attributes to enable

error[E0658]: The `!` type is experimental (see issue #35121)
  --> src/executor.rs:11:47
   |
11 |     fn new(fut: Box<Future<Item = (), Error = !> + 'static>) -> TaskInfo {
   |                                               ^
   |
   = help: add #![feature(never_type)] to the crate attributes to enable

error[E0658]: The `!` type is experimental (see issue #35121)
  --> src/executor.rs:17:64
   |
17 |     fn get_future(&self) -> &mut Box<Future<Item = (), Error = !> + 'static> {
   |                                                                ^
   |
   = help: add #![feature(never_type)] to the crate attributes to enable

error[E0658]: The `!` type is experimental (see issue #35121)
  --> src/utils.rs:14:18
   |
14 |     type Error = !;
   |                  ^
   |
   = help: add #![feature(never_type)] to the crate attributes to enable

error[E0658]: The `!` type is experimental (see issue #35121)
  --> src/utils.rs:18:28
   |
18 |     ) -> Result<Async<()>, !> {
   |                            ^
   |
   = help: add #![feature(never_type)] to the crate attributes to enable

error[E0658]: The `!` type is experimental (see issue #35121)
  --> src/net.rs:18:18
   |
18 |     type Error = !;
   |                  ^
   |
   = help: add #![feature(never_type)] to the crate attributes to enable

error[E0658]: The `!` type is experimental (see issue #35121)
  --> src/net.rs:22:47
   |
22 |     ) -> Result<Async<Option<TcpConnection>>, !> {
   |                                               ^
   |
   = help: add #![feature(never_type)] to the crate attributes to enable

error: aborting due to 7 previous errors

For more information about this error, try `rustc --explain E0658`.
error: Could not compile `ia`.
```
It seems to need feature attribute.
So I added feature never_type attribute.